### PR TITLE
Add flags to make it possible to change return styles from osascript

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,8 +130,17 @@ var defaultOptions = {
 };
 ```
 
-Type is passed as language (flag `-l`) to `osascript`.
+Type is passed as language (option `-l`) to `osascript`.
 Can be either `JavaScript` (in Yosemite) or `AppleScript`.
+
+`flags` can be used to change the output style of return values from functions executed by osascript:
+
+```js
+// JSON parsable return
+osascript('(function(){return ["foo",5, {foo: "barz"}]})()', {flags: ['-s', 's']}, function (data) {
+  console.log(data); // ["foo", 5, {"foo":"barz"}]
+});
+```
 
 `args` is a list of strings passed in as arguments to your scripts. In JavaScript
 you can access them using:

--- a/examples/js/return.js
+++ b/examples/js/return.js
@@ -1,0 +1,31 @@
+var osascript = require('../../').eval;
+var script = '(function(){return ["foo",5, {foo: "barz"}]})()';
+
+/**
+ * Quote from https://developer.apple.com/library/mac/documentation/Darwin/Reference/ManPages/man1/osascript.1.html
+ * > osascript normally prints its results in human-readable form: strings do not have quotes
+ * > around them, characters are not escaped, braces for lists and records are omitted, etc.  This
+ * > is generally more useful, but can introduce ambiguities.  For example, the lists `{"foo",
+ * > "bar"}' and `{{"foo", {"bar"}}}' would both be displayed as `foo, bar'.  To see the results in
+ * > an unambiguous form that could be recompiled into the same value, use the s modifier.
+ */
+
+// Default return
+osascript(script, function (err, data) {
+	if (err == null) {
+		console.log('typeof data ->', typeof data);
+		console.log('data ->', data);
+	} else {
+		console.log(err);
+	}
+});
+
+// JSON parsable return
+osascript(script, {type: 'JavaScript', flags: ['-s', 's']}, function (err, data) {
+	if (err == null) {
+		console.log('typeof data ->', typeof data);
+		console.log('data ->', data);
+	} else {
+		console.log(err);
+	}
+});

--- a/examples/js/return.js
+++ b/examples/js/return.js
@@ -12,20 +12,20 @@ var script = '(function(){return ["foo",5, {foo: "barz"}]})()';
 
 // Default return
 osascript(script, function (err, data) {
-	if (err == null) {
-		console.log('typeof data ->', typeof data);
-		console.log('data ->', data);
-	} else {
-		console.log(err);
-	}
+  if (err == null) {
+    console.log('typeof data ->', typeof data);
+    console.log('data ->', data);
+  } else {
+    console.log(err);
+  }
 });
 
 // JSON parsable return
 osascript(script, {type: 'JavaScript', flags: ['-s', 's']}, function (err, data) {
-	if (err == null) {
-		console.log('typeof data ->', typeof data);
-		console.log('data ->', data);
-	} else {
-		console.log(err);
-	}
+  if (err == null) {
+    console.log('typeof data ->', typeof data);
+    console.log('data ->', data);
+  } else {
+    console.log(err);
+  }
 });

--- a/index.js
+++ b/index.js
@@ -85,14 +85,14 @@ function argify (opts, file) {
 
   if ((file && isAppleScript(file) && !opts.type) ||
       (opts.type && opts.type.toLowerCase() === 'applescript')) {
-    return [].concat(args);
+    return [].concat(args, opts.flags || []);
   }
 
   if (opts.type) {
-    return ['-l', opts.type].concat(args);
+    return ['-l', opts.type].concat(args, opts.flags || []);
   }
 
-  return ['-l', 'JavaScript'].concat(args);
+  return ['-l', 'JavaScript'].concat(args, opts.flags || []);
 }
 
 function isAppleScript (file) {

--- a/index.js
+++ b/index.js
@@ -89,7 +89,7 @@ function argify (opts, file) {
   }
 
   if (opts.type) {
-    return ['-l', opts.type.toLowerCase()].concat(args);
+    return ['-l', opts.type].concat(args);
   }
 
   return ['-l', 'JavaScript'].concat(args);


### PR DESCRIPTION
Makes it possible to return a string representation of an JavaScript object from JXA back in the node.js world:

``` js
// Default return
osascript('(function(){return ["foo",5, {foo: "barz"}]})()', function (data) {
  console.log(data); // foo, 5, foo:barz
});

// JSON parsable return
osascript('(function(){return ["foo",5, {foo: "barz"}]})()', {flags: ['-s', 's']}, function (data) {
  console.log(data); // ["foo", 5, {"foo":"barz"}]
});
```

See `examples/js/return.js` and [osascript man page](https://developer.apple.com/library/mac/documentation/Darwin/Reference/ManPages/man1/osascript.1.html)

---

I could squash commits if you prefer a shorter history :octocat: 
